### PR TITLE
Fix deprecation warning for the context menu

### DIFF
--- a/menus/open-in-github-app.cson
+++ b/menus/open-in-github-app.cson
@@ -1,7 +1,8 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'Open in GitHub.app': 'open-in-github-app:open'
+  'atom-workspace': [
+    {label: 'Open in GitHub app', command: 'command':'open-in-github-app:open'}
+  ]
 
 'menu': [
   {
@@ -9,7 +10,7 @@
     'submenu': [
       'label': 'GitHub App'
       'submenu': [
-        { 'label': 'Open in GitHub.app', 'command': 'open-in-github-app:open' }
+        { 'label': 'Open in GitHub app', 'command': 'open-in-github-app:open' }
       ]
     ]
   }


### PR DESCRIPTION
When trying to create tests for my windows supporting PR, i found this :astonished:

![image](https://cloud.githubusercontent.com/assets/238079/5092214/65a007be-6f1b-11e4-99bc-9a0b6ba66851.png)

This PR updates the context menu to remove the deprecation warning:

![image](https://cloud.githubusercontent.com/assets/238079/5092284/e63b004a-6f1b-11e4-96f2-df1c233060cd.png)

i changed the text of the context menu to `Open in GitHub app` because `GitHub.app` isn't a thing in the magical land we call Windows :wink:. Let me know if you want it to be something else.

Sadly, it doesn't fix my poorly written tests, even after i wished really hard :cry: 