### PR TITLE
Replacing deprecated workspaceView Call

### DIFF
--- a/lib/open-in-github-app.coffee
+++ b/lib/open-in-github-app.coffee
@@ -3,7 +3,7 @@ shell = require('shell')
 
 module.exports =
   activate: (state) ->
-    atom.workspaceView.command "open-in-github-app:open", => @openApp()
+    atom.views.getView(atom.workspace).command "open-in-github-app:open", => @openApp()
 
   openApp: ->
     @path = atom.project?.getPath()


### PR DESCRIPTION
Per changes to package API in atom 1.76+, workspaceView has been
replaced with views.getView(atom.workspace)